### PR TITLE
Add Ona Automations configuration to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1919,6 +1919,17 @@
       ],
       "url": "https://json.schemastore.org/omnisharp.json"
     },
+     {
+      "name": "Ona Automations",
+      "description": "Configuration for Ona Automations",
+      "fileMatch": [
+        "**/.ona/automations.json",
+        "**/.ona/automations.yaml",
+        "**/.ona/automations.yml",
+        "**/.ona/automation.yaml"
+      ],
+      "url": "https://app.ona.com/jsonschema/v1/automations_file.jsonschema.json"
+    },
     {
       "name": "openapi.json",
       "description": "A JSON schema for Open API documentation files",


### PR DESCRIPTION
Added configuration for Ona Automations with file matches and schema URL.

This follows a rename of Gitpod to Ona. I'll raise a follow-up PR to remove Gitpod from the catalogue at the end of 2025.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
